### PR TITLE
Implement basic support for MDX file format

### DIFF
--- a/WoWFormatLib/FileReaders/MDXReader.cs
+++ b/WoWFormatLib/FileReaders/MDXReader.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using WoWFormatLib.Structs.MDX;
+
+namespace WoWFormatLib.FileReaders
+{
+    public class MDXReader
+    {
+        public MDXModel model;
+
+        public void LoadModel(Stream stream)
+        {
+            BinaryReader data = new BinaryReader(stream);
+
+            // Magic check.
+            MDXChunks magic = (MDXChunks)data.ReadUInt32();
+            if (magic != MDXChunks.MDLX)
+                throw new Exception(string.Format("Invalid MDX header? Got {0}, expected {1}", magic.ToString("X"), MDXChunks.MDLX.ToString("X")));
+
+            long pos = 4; // Start just ahead of magic.
+            while (pos < stream.Length)
+            {
+                stream.Position = pos;
+
+                MDXChunks chunkID = (MDXChunks)data.ReadUInt32();
+                uint chunkLength = data.ReadUInt32();
+
+                // Ensure that reading of the next chunk will start in the right place
+                // regardless of where we stop parsing this one.
+                pos = stream.Position + chunkLength;
+
+                switch (chunkID)
+                {
+                    case MDXChunks.VERS: ParseChunk_VERS(data); break;
+                    case MDXChunks.MODL: ParseChunk_MODL(data); break;
+                    case MDXChunks.GEOS: ParseChunk_GEOS(data, stream, chunkLength); break;
+                    default:
+                        Console.WriteLine("Skipping unknown MDX chunk: {0}", chunkID.ToString("X"));
+                        break;
+                }
+            }
+        }
+
+        private void ParseChunk_VERS(BinaryReader data)
+        {
+            model.version = data.ReadUInt32();
+        }
+
+        private void ParseChunk_MODL(BinaryReader data)
+        {
+            // Model names are always a fixed length of 50 bytes.
+            byte[] nameBytes = data.ReadBytes(50);
+            model.name = Encoding.UTF8.GetString(nameBytes).Replace("\0", string.Empty);
+        }
+
+        private void ParseChunk_GEOS(BinaryReader data, Stream stream, uint chunkLength)
+        {
+            List<Geoset> geosets = new List<Geoset>();
+
+            long chunkEnd = stream.Position + chunkLength;
+            while (stream.Position < chunkEnd)
+            {
+                long geosetStart = stream.Position;
+                uint geosetSize = data.ReadUInt32();
+                long geosetEnd = geosetStart + geosetSize;
+
+                geosets.Add(ParseGeoset(data, stream, geosetEnd));
+                stream.Position = geosetEnd;
+            }
+
+            model.geosets = geosets.ToArray();
+        }
+
+        private Geoset ParseGeoset(BinaryReader data, Stream stream, long end)
+        {
+            Geoset geoset = new Geoset{};
+            while (stream.Position < end)
+            {
+                MDXChunks chunkID = (MDXChunks)data.ReadUInt32();
+                switch (chunkID)
+                {
+                    case MDXChunks.VRTX: ParseChunk_VRTX(data, ref geoset); break;
+                    case MDXChunks.NRMS: ParseChunk_NRMS(data, ref geoset); break;
+                    case MDXChunks.PTYP: ParseChunk_PTYP(data); break;
+                    case MDXChunks.PCNT: ParseChunk_PCNT(data); break;
+                    case MDXChunks.PVTX: ParseChunk_PVTX(data, ref geoset); break;
+                    case MDXChunks.GNDX: ParseChunk_GNDX(data); break;
+                    case MDXChunks.MTGC: ParseChunk_MTGC(data); break;
+                    case MDXChunks.MATS: ParseChunk_MATS(data); break;
+                    case MDXChunks.TANG: ParseChunk_TANG(data); break;
+                    case MDXChunks.SKIN: ParseChunk_SKIN(data); break;
+                    case MDXChunks.UVAS: ParseChunk_UVAS(data, stream, ref geoset); break;
+                    default:
+                        // Unknown/unimplemented geoset data. Breakpoint here to evaluate.
+                        stream.Position = end;
+                        break;
+                }
+            }
+            return geoset;
+        }
+
+        private void ParseChunk_VRTX(BinaryReader data, ref Geoset geoset)
+        {
+            uint vertCount = data.ReadUInt32();
+            Vert[] verts = new Vert[vertCount];
+
+            for (int i = 0; i < vertCount; i++)
+                verts[i] = new Vert { x = data.ReadSingle(), y = data.ReadSingle(), z = data.ReadSingle() };
+
+            geoset.verts = verts;
+        }
+
+        private void ParseChunk_NRMS(BinaryReader data, ref Geoset geoset)
+        {
+            uint normalsCount = data.ReadUInt32();
+            Normal[] normals = new Normal[normalsCount];
+
+            for (int i = 0; i < normalsCount; i++)
+                normals[i] = new Normal { x = data.ReadSingle(), y = data.ReadSingle(), z = data.ReadSingle() };
+
+            geoset.normals = normals;
+        }
+
+        private void ParseChunk_PTYP(BinaryReader data)
+        {
+            // According to documentation, these are always triangles (0x4)
+            // Do we ever need to implement this? Just skip it for now.
+            data.Skip((int)data.ReadUInt32() * 4);
+        }
+
+        private void ParseChunk_PCNT(BinaryReader data)
+        {
+            // No point implementing this? Primitives are always triangles (3 points).
+            data.Skip((int)data.ReadUInt32() * 4);
+        }
+
+        private void ParseChunk_PVTX(BinaryReader data, ref Geoset geoset)
+        {
+            uint primitiveVertCount = data.ReadUInt32();
+            uint primitiveCount = primitiveVertCount / 3; // Technically this 3 maps from the PCNT, but it's always 3 so.
+
+            Primitive[] primitives = new Primitive[primitiveCount];
+            for (int i = 0; i < primitiveCount; i++)
+                primitives[i] = new Primitive { v1 = data.ReadUInt16(), v2 = data.ReadUInt16(), v3 = data.ReadUInt16() };
+
+            geoset.primitives = primitives;
+        }
+
+        private void ParseChunk_GNDX(BinaryReader data)
+        {
+            // Not Yet Implemented
+            data.Skip((int)data.ReadUInt32());
+        }
+
+        private void ParseChunk_MTGC(BinaryReader data)
+        {
+            // Not Yet Implemented
+            data.Skip((int)data.ReadUInt32() * 4);
+        }
+
+        private void ParseChunk_MATS(BinaryReader data)
+        {
+            // Not Yet Implemented
+            data.Skip((int)data.ReadUInt32() * 4);
+
+            // This seems version specific (900?), may need additional checks.
+            data.Skip(128); // Geoset material name?
+        }
+
+        private void ParseChunk_TANG(BinaryReader data)
+        {
+            // Not Yet Implemented (No idea what this is)
+            data.Skip((int)data.ReadUInt32() * 16);
+        }
+
+        private void ParseChunk_SKIN(BinaryReader data)
+        {
+            // Not Yet Implemented
+            data.Skip((int)data.ReadUInt32());
+        }
+
+        private void ParseChunk_UVAS(BinaryReader data, Stream stream, ref Geoset geoset)
+        {
+            uint chunkCount = data.ReadUInt32();
+
+            if ((MDXChunks)data.ReadUInt32() == MDXChunks.UVBS)
+            {
+                // MDX 900 UVAS appears to contain UVBS sub-chunks.
+                // Not encountered one that has more than one, so there's some over-riding occuring here.
+                for (int i = 0; i < chunkCount; i++)
+                    ParseChunk_UVBS(data, ref geoset);
+            }
+            else
+            {
+                // UVAS matches documentation, so treat it like one UVBS chunk.
+                stream.Seek(-8, SeekOrigin.Current);
+                ParseChunk_UVBS(data, ref geoset);
+            }
+        }
+
+        private void ParseChunk_UVBS(BinaryReader data, ref Geoset geoset)
+        {
+            uint uvCount = data.ReadUInt32();
+            UV[] uvs = new UV[uvCount];
+
+            for (int i = 0; i < uvCount; i++)
+                uvs[i] = new UV { x = data.ReadSingle(), y = data.ReadSingle() };
+
+            geoset.uvs = uvs;
+        }
+    }
+}

--- a/WoWFormatLib/Structs/MDX.struct.cs
+++ b/WoWFormatLib/Structs/MDX.struct.cs
@@ -1,0 +1,64 @@
+﻿namespace WoWFormatLib.Structs.MDX
+{
+    public enum MDXChunks
+    {
+        MDLX = 'M' << 0 | 'D' << 8 | 'L' << 16 | 'X' << 24,
+        VERS = 'V' << 0 | 'E' << 8 | 'R' << 16 | 'S' << 24,
+        MODL = 'M' << 0 | 'O' << 8 | 'D' << 16 | 'L' << 24,
+        GEOS = 'G' << 0 | 'E' << 8 | 'O' << 16 | 'S' << 24,
+        VRTX = 'V' << 0 | 'R' << 8 | 'T' << 16 | 'X' << 24,
+        NRMS = 'N' << 0 | 'R' << 8 | 'M' << 16 | 'S' << 24,
+        PTYP = 'P' << 0 | 'T' << 8 | 'Y' << 16 | 'P' << 24,
+        PCNT = 'P' << 0 | 'C' << 8 | 'N' << 16 | 'T' << 24,
+        PVTX = 'P' << 0 | 'V' << 8 | 'T' << 16 | 'X' << 24,
+        UVAS = 'U' << 0 | 'V' << 8 | 'A' << 16 | 'S' << 24,
+        UVBS = 'U' << 0 | 'V' << 8 | 'B' << 16 | 'S' << 24,
+        GNDX = 'G' << 0 | 'N' << 8 | 'D' << 16 | 'X' << 24,
+        MTGC = 'M' << 0 | 'T' << 8 | 'G' << 16 | 'C' << 24,
+        MATS = 'M' << 0 | 'A' << 8 | 'T' << 16 | 'S' << 24,
+        TANG = 'T' << 0 | 'A' << 8 | 'N' << 16 | 'G' << 24,
+        SKIN = 'S' << 0 | 'K' << 8 | 'I' << 16 | 'N' << 24
+    }
+
+    public struct MDXModel
+    {
+        public uint version;
+        public string name;
+        public Geoset[] geosets;
+    }
+
+    public struct Geoset
+    {
+        public Vert[] verts;
+        public Normal[] normals;
+        public Primitive[] primitives;
+        public UV[] uvs;
+    }
+
+    public struct Vert
+    {
+        public float x;
+        public float y;
+        public float z;
+    }
+
+    public struct Normal
+    {
+        public float x;
+        public float y;
+        public float z;
+    }
+
+    public struct Primitive
+    {
+        public uint v1;
+        public uint v2;
+        public uint v3;
+    }
+
+    public struct UV
+    {
+        public float x;
+        public float y;
+    }
+}


### PR DESCRIPTION
This PR implements basic support for the MDX file format. Specifically, the support mostly adheres to version 900 of the file format found in Warcraft III Reforged, however conforms with other file format implementations in the library allowing easy expansion.

Feature wise, currently only basic 3D geometry is supported, however expanding for more features should be trivial for those interested in doing so.