### PR TITLE
Fix memory issues with models containing multiple UVBS chunks

### DIFF
--- a/WoWFormatLib/FileReaders/MDXReader.cs
+++ b/WoWFormatLib/FileReaders/MDXReader.cs
@@ -99,7 +99,7 @@ namespace WoWFormatLib.FileReaders
                     case MDXChunks.PVTX: ParseChunk_PVTX(data, ref geoset); break;
                     case MDXChunks.GNDX: ParseChunk_GNDX(data); break;
                     case MDXChunks.MTGC: ParseChunk_MTGC(data); break;
-                    case MDXChunks.MATS: ParseChunk_MATS(data); break;
+                    case MDXChunks.MATS: ParseChunk_MATS(data, ref geoset); break;
                     case MDXChunks.TANG: ParseChunk_TANG(data); break;
                     case MDXChunks.SKIN: ParseChunk_SKIN(data); break;
                     case MDXChunks.UVAS: ParseChunk_UVAS(data, stream, ref geoset); break;
@@ -171,13 +171,15 @@ namespace WoWFormatLib.FileReaders
             data.Skip((int)data.ReadUInt32() * 4);
         }
 
-        private void ParseChunk_MATS(BinaryReader data)
+        private void ParseChunk_MATS(BinaryReader data, ref Geoset geoset)
         {
             // Not Yet Implemented
             data.Skip((int)data.ReadUInt32() * 4);
 
             // This seems version specific (900?), may need additional checks.
-            data.Skip(128); // Geoset material name?
+            data.Skip(16); // Flags?
+            byte[] geosetName = data.ReadBytes(112); // 112 name bytes?
+            geoset.name = Encoding.UTF8.GetString(geosetName).Replace("\0", string.Empty);
         }
 
         private void ParseChunk_TANG(BinaryReader data)

--- a/WoWFormatLib/FileReaders/MDXReader.cs
+++ b/WoWFormatLib/FileReaders/MDXReader.cs
@@ -57,20 +57,31 @@ namespace WoWFormatLib.FileReaders
 
         private void ParseChunk_GEOS(BinaryReader data, Stream stream, uint chunkLength)
         {
-            List<Geoset> geosets = new List<Geoset>();
-
             long chunkEnd = stream.Position + chunkLength;
+
+            // Pre-calculate how many geosets we have to save memory.
+            uint geosetCount = 0;
+            while (stream.Position < chunkEnd)
+            {
+                geosetCount++;
+                stream.Seek(data.ReadUInt32() - 4, SeekOrigin.Current);
+            }
+
+            stream.Position = chunkEnd - chunkLength;
+            Geoset[] geosets = new Geoset[geosetCount];
+
+            uint geosetIndex = 0;
             while (stream.Position < chunkEnd)
             {
                 long geosetStart = stream.Position;
                 uint geosetSize = data.ReadUInt32();
                 long geosetEnd = geosetStart + geosetSize;
 
-                geosets.Add(ParseGeoset(data, stream, geosetEnd));
+                geosets[geosetIndex++] = ParseGeoset(data, stream, geosetEnd);
                 stream.Position = geosetEnd;
             }
 
-            model.geosets = geosets.ToArray();
+            model.geosets = geosets;
         }
 
         private Geoset ParseGeoset(BinaryReader data, Stream stream, long end)
@@ -185,19 +196,12 @@ namespace WoWFormatLib.FileReaders
         {
             uint chunkCount = data.ReadUInt32();
 
-            if ((MDXChunks)data.ReadUInt32() == MDXChunks.UVBS)
-            {
-                // MDX 900 UVAS appears to contain UVBS sub-chunks.
-                // Not encountered one that has more than one, so there's some over-riding occuring here.
-                for (int i = 0; i < chunkCount; i++)
-                    ParseChunk_UVBS(data, ref geoset);
-            }
-            else
-            {
-                // UVAS matches documentation, so treat it like one UVBS chunk.
+            // 900 UVAS contain UVBS sub-chunks. If it doesn't, treat it like an old UVAS.
+            // Note: No idea what the use of auxiliary UVBS chunks are, so we ignore them.
+            if ((MDXChunks)data.ReadUInt32() != MDXChunks.UVBS)
                 stream.Seek(-8, SeekOrigin.Current);
-                ParseChunk_UVBS(data, ref geoset);
-            }
+
+            ParseChunk_UVBS(data, ref geoset);
         }
 
         private void ParseChunk_UVBS(BinaryReader data, ref Geoset geoset)

--- a/WoWFormatLib/Structs/MDX.struct.cs
+++ b/WoWFormatLib/Structs/MDX.struct.cs
@@ -33,6 +33,7 @@
         public Normal[] normals;
         public Primitive[] primitives;
         public UV[] uvs;
+        public string name;
     }
 
     public struct Vert


### PR DESCRIPTION
In my efforts to fix this, I refactored one of the functions to no longer use an auxiliary List for housing. It instead now reads ahead to calculate the amount of anticipated geosets. While this was entirely unrelated, I decided there was no reason not to keep it.